### PR TITLE
Fixing source and target incorrect encoding

### DIFF
--- a/qpid-proton4j-codec/src/main/java/org/apache/qpid/proton4j/codec/encoders/messaging/SourceTypeEncoder.java
+++ b/qpid-proton4j-codec/src/main/java/org/apache/qpid/proton4j/codec/encoders/messaging/SourceTypeEncoder.java
@@ -52,10 +52,10 @@ public class SourceTypeEncoder extends AbstractDescribedListTypeEncoder<Source> 
                 state.getEncoder().writeString(buffer, state, source.getAddress());
                 break;
             case 1:
-                state.getEncoder().writeObject(buffer, state, source.getDurable());
+                state.getEncoder().writeUnsignedInteger(buffer, state, source.getDurable().getValue());
                 break;
             case 2:
-                state.getEncoder().writeObject(buffer, state, source.getExpiryPolicy());
+                state.getEncoder().writeObject(buffer, state, source.getExpiryPolicy().getPolicy());
                 break;
             case 3:
                 state.getEncoder().writeUnsignedInteger(buffer, state, source.getTimeout());

--- a/qpid-proton4j-codec/src/main/java/org/apache/qpid/proton4j/codec/encoders/messaging/TargetTypeEncoder.java
+++ b/qpid-proton4j-codec/src/main/java/org/apache/qpid/proton4j/codec/encoders/messaging/TargetTypeEncoder.java
@@ -52,10 +52,10 @@ public class TargetTypeEncoder extends AbstractDescribedListTypeEncoder<Target> 
                 state.getEncoder().writeString(buffer, state, target.getAddress());
                 break;
             case 1:
-                state.getEncoder().writeObject(buffer, state, target.getDurable());
+                state.getEncoder().writeUnsignedInteger(buffer, state, target.getDurable().getValue());
                 break;
             case 2:
-                state.getEncoder().writeObject(buffer, state, target.getExpiryPolicy());
+                state.getEncoder().writeObject(buffer, state, target.getExpiryPolicy().getPolicy());
                 break;
             case 3:
                 state.getEncoder().writeUnsignedInteger(buffer, state, target.getTimeout());
@@ -66,7 +66,7 @@ public class TargetTypeEncoder extends AbstractDescribedListTypeEncoder<Target> 
             case 5:
                 state.getEncoder().writeMap(buffer, state, target.getDynamicNodeProperties());
                 break;
-            case 7:
+            case 6:
                 state.getEncoder().writeArray(buffer, state, target.getCapabilities());
                 break;
             default:

--- a/qpid-proton4j-codec/src/test/java/org/apache/qpid/proton4j/codec/SourceCodeTest.java
+++ b/qpid-proton4j-codec/src/test/java/org/apache/qpid/proton4j/codec/SourceCodeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton4j.codec;
+
+import org.apache.qpid.proton4j.amqp.messaging.Source;
+import org.apache.qpid.proton4j.amqp.messaging.TerminusDurability;
+import org.apache.qpid.proton4j.buffer.ProtonBuffer;
+import org.apache.qpid.proton4j.buffer.ProtonByteBufferAllocator;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for handling Source serialization
+ */
+
+public class SourceCodeTest extends CodecTestSupport {
+
+   @Test
+   public void testWriteSource() throws Exception {
+
+      ProtonBuffer buffer = ProtonByteBufferAllocator.DEFAULT.allocate();
+
+      Source value = new Source();
+      value.setAddress("test");
+      value.setDurable(TerminusDurability.UNSETTLED_STATE);
+
+      encoder.writeObject(buffer, encoderState, value);
+
+      final Source result = (Source)decoder.readObject(buffer, decoderState);
+
+      assertEquals("test", result.getAddress());
+      assertEquals(TerminusDurability.UNSETTLED_STATE, result.getDurable());
+
+   }
+}

--- a/qpid-proton4j-codec/src/test/java/org/apache/qpid/proton4j/codec/TargetCodeTest.java
+++ b/qpid-proton4j-codec/src/test/java/org/apache/qpid/proton4j/codec/TargetCodeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton4j.codec;
+
+import org.apache.qpid.proton4j.amqp.messaging.Source;
+import org.apache.qpid.proton4j.amqp.messaging.Target;
+import org.apache.qpid.proton4j.amqp.messaging.TerminusDurability;
+import org.apache.qpid.proton4j.buffer.ProtonBuffer;
+import org.apache.qpid.proton4j.buffer.ProtonByteBufferAllocator;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for handling Source serialization
+ */
+
+public class TargetCodeTest extends CodecTestSupport {
+
+   @Test
+   public void testWriteSource() throws Exception {
+
+      ProtonBuffer buffer = ProtonByteBufferAllocator.DEFAULT.allocate();
+
+      Target value = new Target();
+      value.setAddress("test");
+      value.setDurable(TerminusDurability.UNSETTLED_STATE);
+
+      encoder.writeObject(buffer, encoderState, value);
+
+      final Target result = (Target)decoder.readObject(buffer, decoderState);
+
+      assertEquals("test", result.getAddress());
+      assertEquals(TerminusDurability.UNSETTLED_STATE, result.getDurable());
+
+   }
+}


### PR DESCRIPTION
I looked how those are encoded in Proton. It seems a mistake during the conversion to the new codebase.